### PR TITLE
Add live status info, pointer to console and live in-page support chat!

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,6 @@ url: https://cloud.18f.gov
 description: "cloud.gov is a Platform-as-a-Service based on Cloud Foundry offered by 18F DevOps enabling agile teams to deploy software as fast as they can iterate."
 
 # Exclusions: Don't include these files in the generated site
-# TODO: For some reason these are still appearing in the generated directory when they shouldn't!
 exclude: [LICENCE, LICENSE, README.md]
 
 # Color settings (hex-codes without the leading hash-tag)

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2">
                 <h2>Contact</h2>
-                <p>Dolor reprehenderit repellendus, optio labore odio at tempore debitis nisi. Quasi debitis tenetur eaque molestias non porro odio sapiente.</p>
+                <p>We'll be extending access to interested federal agencies in the coming months. If you'd like to talk more about how you can use cloud.gov, please contact us.</p>
                 <p><a href="mailto:{{ site.email }}">{{ site.email }}</a>
                 </p>
                 <ul class="list-inline banner-social-buttons">

--- a/_includes/css/statuspage.css
+++ b/_includes/css/statuspage.css
@@ -1,0 +1,29 @@
+// The CSS for the colored light that represents the current status per statuspage.io
+// $red:#e74c3c;
+// $orange:#e67e22;
+// $yellow:#f1c40f;
+// $green:#2ecc71;
+
+.statuspagecolor-light {
+  @include border-radius(99px);
+  display:inline-block;
+  width:10px;
+  height:10px;
+  margin-right:5px;
+}
+
+.statuspagecolor-light.critical {
+  color:#e74c3c;
+}
+
+.statuspagecolor-light.major {
+  color:#e67e22;
+}
+
+.statuspagecolor-light.minor {
+  color:#f1c40f;
+}
+
+.statuspagecolor-light.none {
+  color:#2ecc71;
+}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,24 @@
     <!-- Footer -->
     <footer>
         <div class="container text-center">
-            <p>Copyright &copy; {{ site.footer }} 20{{ site.time | date: '%y' }}</p>
+        	<p>
+        		<a class="page-scroll" href="https://cloudgov.statuspage.io/" target="_blank">
+        			<span class="statuspagecolor-light"><i class="fa fa-lightbulb-o"></i>
+        				<span class="statuspagecolor-description"></span>
+    				</span>
+        		</a>
+    		</p>
+        	<p>
+        		<a href="https://github.com/jeromelachaud/grayscale-theme">Grayscale Jekyll theme</a>
+        			courtesy of Jerome Lachaud. 
+    			<a href="http://www.flickr.com/photos/62681247@N00/6575973407/" 
+    				target="_blank" 
+					title="Banner image source">
+					<img src="https://d78fikflryjgj.cloudfront.net/images/d906fe5c1274c56c5571d49705547587/cc.png" 
+						style="height: 14px; width: 14px; vertical-align: middle;" title="http://creativecommons.org/licenses/by/2.0/deed.en" />
+					Cloud imagery
+				</a> courtesy of jqmj (Queralt).
+			</p>
+        	<p>Copyright &copy; {{ site.footer }} 20{{ site.time | date: '%y' }}.</p>
         </div>
     </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
             <div class="container">
                 <div class="row">
                     <div class="col-md-8 col-md-offset-2">
-                        <h1 class="brand-heading">Your team, multiplied</h1>
+                        <h1 class="brand-heading">Your team, unleashed</h1>
                         <p class="intro-text">Abstract away everything required to build and deploy software except the code.</p>
                         <a href="#about" class="btn btn-circle page-scroll">
                             <i class="fa fa-angle-double-down animated"></i>

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -12,3 +12,7 @@
 
     <!-- Custom Theme JavaScript -->
     <script src="{{ "/js/grayscale.js" | prepend: site.baseurl }}"></script>
+
+    <!-- HappyFox Live Chat Script -->
+    <script src="{{ "/js/happyfoxchat.js" | prepend: site.baseurl }}"></script>
+    

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -13,6 +13,12 @@
     <!-- Custom Theme JavaScript -->
     <script src="{{ "/js/grayscale.js" | prepend: site.baseurl }}"></script>
 
+    <!-- statuspage.io widget support code-->
+    <script src="https://cdn.statuspage.io/se-v2.js"></script>
+    
+    <!-- statuspage.io implementation in page-->
+    <script src="{{ "/js/statuspage.js" | prepend: site.baseurl }}"></script>
+
     <!-- HappyFox Live Chat Script -->
     <script src="{{ "/js/happyfoxchat.js" | prepend: site.baseurl }}"></script>
     

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,6 +21,11 @@
                         <a class="page-scroll" href="#about">About</a>
                     </li>
                     <li>
+                        <a class="page-scroll" href="https://console.18f.gov">
+                            <i class="fa fa-wrench"></i> Console
+                        </a>
+                    </li>
+                    <li>
                         <a class="page-scroll" href="#download">Download</a>
                     </li>
                     <li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -32,11 +32,18 @@
                             </span> Status
                         </a>
                     </li>
-                    <li>
+<!--                     <li>
                         <a class="page-scroll" href="#download">Download</a>
                     </li>
+ -->                    
                     <li>
-                        <a class="page-scroll" href="#contact">Contact</a>
+                        <a class="page-scroll" href="https://docs.18f.gov" target="_blank">
+                            <i class="fa fa-book"></i> Documentation</a>
+                    </li>
+                    <li>
+                        <a class="page-scroll" href="#contact">
+                            <i class="fa fa-comments-o"></i> Contact
+                        </a>
                     </li>
                 </ul>
             </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,8 +21,10 @@
                         <a class="page-scroll" href="#about">About</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="https://console.18f.gov">
-                            <i class="fa fa-wrench"></i> Console
+                        <a class="page-scroll" href="https://cloudgov.statuspage.io/" target="_blank">
+                            <span class="statuspagecolor-light">
+                                <i class="fa fa-lightbulb-o"></i>
+                            </span> Status
                         </a>
                     </li>
                     <li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,6 +21,11 @@
                         <a class="page-scroll" href="#about">About</a>
                     </li>
                     <li>
+                        <a class="page-scroll" href="https://console.18f.gov" target="_blank">
+                            <i class="fa fa-wrench"></i> Console
+                        </a>
+                    </li>
+                    <li>
                         <a class="page-scroll" href="https://cloudgov.statuspage.io/" target="_blank">
                             <span class="statuspagecolor-light">
                                 <i class="fa fa-lightbulb-o"></i>

--- a/_layouts/style.css
+++ b/_layouts/style.css
@@ -1,3 +1,4 @@
 {% include css/bootstrap.min.css %}
 /* {% include css/grayscale.css %} */
+{% include css/statuspage.css %}
 {% include css/cloudgov.css %}

--- a/js/happyfoxchat.js
+++ b/js/happyfoxchat.js
@@ -1,0 +1,18 @@
+    <!-- HappyFox Live Chat Script -->
+    window.HFCHAT_CONFIG = {
+      EMBED_TOKEN: "995a2db0-46bf-11e5-986c-5b521052aa24",
+      ACCESS_TOKEN: "a5ba09020f0d40ae9eb91e299800cd47",
+      HOST_URL: "https://www.happyfoxchat.com",
+      ASSETS_URL: "https://d1l7z5ofrj6ab8.cloudfront.net/visitor"
+  };
+
+  (function() {
+      var scriptTag = document.createElement('script');
+      scriptTag.type = 'text/javascript';
+      scriptTag.async = true;
+      scriptTag.src = window.HFCHAT_CONFIG.ASSETS_URL + '/js/widget-loader.js';
+
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(scriptTag, s);
+  })();
+  <!--End of HappyFox Live Chat Script-->

--- a/js/statuspage.js
+++ b/js/statuspage.js
@@ -1,0 +1,16 @@
+
+var sp = new StatusPage.page({ page : 'swcbylb1c30f' });
+sp.status({
+	success : function(data) {
+		// Uncomment to inspect the actual values
+		// console.log(data.status.indicator);
+		// console.log(data.status.description);		
+
+	    // appends the status indicator as a class name so we can use the right color for the status light thing
+    	$('.statuspagecolor-light').addClass(data.status.indicator);
+    	$('.statuspagecolor-description').addClass(data.status.indicator);
+
+	    // adds the text description of the status
+	    $('.statuspagecolor-description').text(data.status.description);
+	}
+});

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,5 @@ applications:
   env:
     FORCE_HTTPS: true
   host: cf-landing
+  path: _site
+  


### PR DESCRIPTION
- Live service status appears at the top and bottom of the page.
  - Summary info directly pulled from https://cloudgov.statuspage.io
  - Clicking either of these takes you directly to the full status page.
- There’s live support chat in the page! 
  - This is configured to alert people in Slack that someone needs help, and there’s a backend console and process for managing those conversations. 
  - Powered by newbie-in-beta HappyFox Chat. Currently the free plan looks like enough for us.
- There’s a prominent link pointing people to console.18f.gov.
- There’s a prominent link pointing people to docs.18f.gov.
