### PR TITLE
Fix Bret's, James's 18F user names

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -40,7 +40,7 @@ testable: true
 #   role: Team member's role; leads should be designated as 'lead'
 team:
 - github: mogul
-  id: mogul
+  id: bret
   role: Product Lead
 - github: dlapiduz
   id: diego
@@ -52,7 +52,7 @@ team:
   id: gabriel.ramirez
   role: Ops Engineer
 - github: jcscottiii
-  id: jamescscott
+  id: james
   role: Ops Engineer
 
 # Partners for whom the project is developed


### PR DESCRIPTION
The `id:` field should match current 18F usernames as reflected in the Hub and https://team-api.18f.gov/public/api/. It's also not strictly necessary so long as the `github:` field is defined and the 18F/team-api repo has that information in each team member's `.yml` file.

This is one of those things we need to better document after I get back from vacation next week.
