### PR TITLE
Don't center the "An official website of the United States Government" text

### DIFF
--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -1,6 +1,3 @@
-.usa-disclaimer {
-  text-align: center;
-}
 .usa-site-navbar {
   padding-top: 1rem;
 }


### PR DESCRIPTION
_Before_:
<img width="1538" alt="screen shot 2015-10-09 at 4 19 14 pm" src="https://cloud.githubusercontent.com/assets/772/10404560/8a599bd4-6ea1-11e5-8ab0-575469b2b46a.png">

_After_:
<img width="1538" alt="screen shot 2015-10-09 at 4 19 17 pm" src="https://cloud.githubusercontent.com/assets/772/10404561/915cad40-6ea1-11e5-933b-1a231b0e0d48.png">
