### PR TITLE
Pa11y fixes

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -8,7 +8,7 @@
     {% endfor %}
     <form id="contact" action="{{ f.url }}" method="POST">
       <fieldset>
-        <h4>{{ f.heading }}</h4>
+        <legend>{{ f.heading }}</legend>
         <div class="usa-width-one-half text_block">
           {% for field in f.fields %}
             {% unless field.type == 'hidden' %}<label for="contact-{{ field.name }}">{{ field.label }}</label>{% endunless %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,14 +11,14 @@
   <div class="header-wrap">
 
     <!-- start logo -->
-    <h2 class="header-title">
+    <div class="header-title">
       <a href="/" class="logo" title="Home">
         <svg class="logo">
           <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#logo' |
              prepend: site.baseurl }}"/>
         </svg>
       </a>
-    </h2>
+    </div>
     <!--end logo -->
 
     <!-- start top navigation -->


### PR DESCRIPTION
Inspired by #58 though it is now out of date because of the redesign. I ran the `HTML_CodeSniffer` tool on the current master branch and tried to fix the items that were in the "Error" category.

This PR changes:
1. The `<h2>` element in the header to be a regular `<div>` since it had no text content
2. The "Contact Us" form to use a `<legend>` instead of an `<h4>`

The tool also complained about color contrast and have opened 18f/cg-style#68 to address that.

Style changes required since using a `<legend>` instead of `<h4>` are addressed in 18F/cg-style#69
