### PR TITLE
Fix #70 ("Feature icons are mismatched")

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -158,7 +158,7 @@ layout: base
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt" style="width: 2.875rem">
-            <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#i-double_arrow' |
+            <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#i-agreement' |
                prepend: site.baseurl }}"/>
           </svg>
         </div>
@@ -172,7 +172,7 @@ layout: base
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#i-locked' |
+            <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#i-double_arrow' |
                prepend: site.baseurl }}"/>
           </svg>
         </div>
@@ -186,7 +186,7 @@ layout: base
       <div class="four_up-part">
         <div class="icon-container">
           <svg class="icon icon-alt">
-            <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#i-agreement' |
+            <use xlink:href="{{ '/assets/img/cloudgov-sprite.svg#i-locked' |
                prepend: site.baseurl }}"/>
           </svg>
         </div>


### PR DESCRIPTION
Re-ordered feature icons so that the locked icon is over "Security", the double-arrow (stretch) icon is over "Scalability", and the agreement (hand shake) icon is over "Usability."
