### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # cloud.gov landing page
 
-The informational website for the cloud.gov PaaS service. Provides information about the platform
-and links to technical documentation and the live console.
+The informational website for the cloud.gov PaaS service. Provides information
+about the platform and links to technical documentation and the live console.
 
 Uses the [U.S. Web Design Standards](https://playbook.cio.gov/designstandards/)
 
 ## Installation
-This site is made with [Jekyll](http://www.jekyllrb.com). Once you've got [Ruby](https://www.ruby-lang.org/) on your computer, you can run:
+This site is made with [Jekyll](http://www.jekyllrb.com). Once you've got
+[Ruby](https://www.ruby-lang.org/) on your computer, you can run:
 
 ```sh
 gem install github-pages
@@ -27,12 +28,17 @@ the source files.
 
 ### Style development
 
-This site uses a shared cloud.gov style, [cg-style](https://github.com/18F/cg-style). This means any styling code has to be developed in *cg-style*.
+This site uses a shared cloud.gov style, [cg-style]. This means any styling
+code has to be developed in *cg-style*.
 
 0. Download or clone the *cg-style* repository, `git clone git@github.com:18F/cg-style.git`
-0. Follow the instructions on the [cg-style readme](https://github.com/18F/cg-style#install-and-use) to install and build the library.
+0. Follow the instructions on the [cg-style readme] to install and build the library.
 0. Run the watching build task in the *cg-style* repository: `npm run watch`
-0. Replace the `gem 'cloudgov-style'` line in the `Gemfile` with `'cloudgov-style', :path => 'path/to/local/cg-style/gem'`.
+0. Replace the `gem 'cloudgov-style'` line in the `Gemfile` with
+    `'cloudgov-style', :path => 'path/to/local/cg-style/gem'`.
 0. Run `bundle` again.
 0. Edit code in the *cg-style* directory and they will propagate down to *cg-landing*
 0. Run `bundle exec jekyll serve --watch`.
+
+[cg-style]: https://github.com/18F/cg-style
+[cg-style readme]: https://github.com/18F/cg-style#install-and-use

--- a/README.md
+++ b/README.md
@@ -7,19 +7,22 @@ Uses the [U.S. Web Design Standards](https://playbook.cio.gov/designstandards/)
 
 ## Installation
 This site is made with [Jekyll](http://www.jekyllrb.com). Once you've got
-[Ruby](https://www.ruby-lang.org/) on your computer, you can run:
+[Ruby](https://www.ruby-lang.org/) on your computer, you can install the
+necessary dependencies using the following commands:
 
 ```sh
-gem install github-pages
+cd cg-landing
+gem install bundler
+bundle install
 ```
 
-(Note: depending on how Ruby was installed, you may need to prefix the above
-command with `sudo`.)
+(Note: depending on how Ruby was installed, you may need to prefix the
+last two commands with `sudo`.)
 
 To start up the local server, run:
 
 ```sh
-jekyll serve --baseurl='' -w
+bundle exec jekyll serve --baseurl='' -w
 ```
 
 Then visit [http://localhost:4000](http://localhost:4000) to view it. The `-w`
@@ -36,7 +39,7 @@ code has to be developed in *cg-style*.
 0. Run the watching build task in the *cg-style* repository: `npm run watch`
 0. Replace the `gem 'cloudgov-style'` line in the `Gemfile` with
     `'cloudgov-style', :path => 'path/to/local/cg-style/gem'`.
-0. Run `bundle` again.
+0. Run `bundle install` again.
 0. Edit code in the *cg-style* directory and they will propagate down to *cg-landing*
 0. Run `bundle exec jekyll serve --watch`.
 


### PR DESCRIPTION
Following the installation instructions in the README, I received this error when executing `jekyll serve --baseurl='' -w`:

> Dependency Error: Yikes! It looks like you don't have kramdown or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- kramdown' If you run into trouble, you can find helpful resources at http://jekyllrb.com/help/!
> jekyll 3.1.6 | Error:  kramdown

The `github-pages` gem was installed, and an extra `gem install kramdown` did not help.  So I switched to `bundle install` and `bundle exec ...`, which fixed the issue.  I have updated the README with these instructions.  (I also snuck in a patch to apply more consistent line wrapping in the README.  If this is undesired, let me know, and I will remove it.)
