### PR TITLE
Fix #67: prevent rendering artifact on click

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: base
 ---
 
 <section class="section section-dark section-chevron_alt section-first" 
-    id="main" tabindex="-1">
+    id="main">
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">
       <h1 class="billboard-display_text">{{ page.hero-text }}</h1>


### PR DESCRIPTION
The issue is that a rendering artifact--a blue or grey non-rectangular outline that cuts through the navigation links--shows up in Chrome when clicking anywhere in the first `<section>` of the home page.  (See issue #67 in bug tracker for a screenshot.)

The cause is that Chrome interprets a `tabindex` attribute on the first `<section>` to mean the element is selectable and should be outlined on click.  The irregularity of the outline (i.e. non-rectangular, half of
it extending beyond the element's content box into the header nav) is due to the `::before` psuedo-element which, itself, extends outside the element to offset its background image.

The fix is to simply remove `tabindex` from the first `<section>`.
