### PR TITLE
Make manifest path configurable.

### DIFF
--- a/ci/credentials.example.yml
+++ b/ci/credentials.example.yml
@@ -7,6 +7,8 @@ cf-space: landing
 cg-landing-git-url: https://github.com/18F/cg-landing.git
 cg-landing-branch: master
 
+manifest-path: cg-landing-compiled/manifest.yml
+
 slack-webhook-url: URL
 slack-channel: '#cloud-gov-liberator'
 slack-username: concourse

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -8,7 +8,7 @@ jobs:
     file: cg-landing-source/ci/build.yml
   - put: cloud-gov-production
     params:
-      manifest: cg-landing-compiled/ci/manifest.fr.yml
+      manifest: {{manifest-path}}
       path: cg-landing-compiled
       current_app_name: invite
     on_failure:


### PR DESCRIPTION
To facilitate reusing the pipeline to deploy into multiple environments. Specifically, we want to use `manifest.yml` to deploy to e/w (for now) and `ci/manifest.fr.yml` to deploy to gc.

cc @afeld

Alternatively, we could add a task to build a new manifest that interpolates parameters like `domain` and `no-hostname`, but this seemed simpler.
