### PR TITLE
add a couple of 'learn more' links

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -99,7 +99,7 @@ layout: base
         <p>
           We remove the complexity of the cloud infrastructure and give you a
           usable interface that you can use to deploy secure apps quickly. This
-          is platform-as-a-service, or PaaS.
+          is platform-as-a-service, or PaaS. <a href="https://docs.cloud.gov/intro/overview/what-is-cloudgov/">Learn more.</a>
         </p>
       </div>
       <div class="three_up-part">
@@ -115,7 +115,7 @@ layout: base
           As a byproduct of building the platform, we have open source,
           software-friendly documentation of cloud.gov’s NIST controls, ready to
           incorporate into your own FISMA and ATO documentation, however you
-          need it.
+          need it. <a href="https://docs.cloud.gov/intro/overview/what-is-cloudgov/#cloud-gov-provides-a-compliance-toolkit">Learn more.</a>
         </p>
       </div>
       <div class="three_up-part">


### PR DESCRIPTION
Follow-up to https://github.com/18F/cg-landing/pull/37. I was reminded again looking at it today that our homepage doesn't really lead people into the documentation. Short of doing https://github.com/18F/cg-docs/issues/332 (which would need something similar anyway), this adds a couple of links into our Introduction section.

We could probably stick more in there, but this is a start.

![screen shot 2016-08-21 at 3 17 20 pm](https://cloud.githubusercontent.com/assets/86842/17839320/64051a16-67b2-11e6-92ea-d9a9aa604687.png)

/cc @berndverst 
