### PR TITLE
Update footer html to use correct slim footer html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,8 +17,10 @@
             </li>
           </ul>
         </nav>
-        <div class="usa-width-one-third usa-footer-primary-content">
-          <a href="mailto:{{ site.footer.email }}">{{ site.footer.email }}</a>
+        <div class="usa-width-one-third">
+          <div class="usa-footer-primary-content usa-footer-contact_info">
+            <a href="mailto:{{ site.footer.email }}">{{ site.footer.email }}</a>
+          </div>
         </div>          
       </div>
     </div>


### PR DESCRIPTION
See Standards code example here: https://standards.usa.gov/footers/#slim-footer

This does not effect the visual representation and is purely architectural. It also helps avoid an issue with the `v0.12.1` release upgrade work being done on `cg-style` here: https://github.com/18F/cg-style/pull/147
