### PR TITLE
Update icon color to specify current red coloring.

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -23,3 +23,7 @@
     margin: 0;
   }
 }
+
+.icon-alt {
+  stroke: #E74C3C;
+}


### PR DESCRIPTION
This pull request makes explicit the stroke coloring for the icons on the [Cloud.gov landing page](https://cloud.gov/). This change will need to be merged in before we can make the update to `v0.12.1` of the Standards for `cg-style`.

Refs https://github.com/18F/cg-style/pull/147
