### PR TITLE
Updates Cloud.gov Lead Signup form

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -9,9 +9,23 @@
     <form action="//gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=ab90bdad59" method="post" id="contact" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
       <fieldset>
         <h4>Sign up for updates about the availability of cloud.gov from 18F</h4>
-        <div class="usa-width-one-half text_block">
+        <div class="text_block">
           <label for="mce-EMAIL">Email Address </label>
           <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+        <label for="mce-FUNCTION">Function </label>
+        <select name="FUNCTION" style="line-height: 130%; font-size: 1rem; padding: 0.7rem;" id="mce-FUNCTION">
+          <option value=""></option>
+          <option value="Program Manager / Product Manager">Program Manager / Product Manager</option>
+          <option value="Executive">Executive</option>
+          <option value="Technical Staff">Technical Staff</option>
+        </select>
+        <label for="mce-SECTOR">Sector </label>
+        <select name="SECTOR" style="line-height: 130%; font-size: 1rem; padding: 0.7rem;" id="mce-SECTOR">
+          <option value=""></option>
+          <option value="Government">Government</option>
+          <option value="Government Contractor / Vendor">Government Contractor / Vendor</option>
+          <option value="Other Private Sector">Other Private Sector</option>
+        </select>
 
           <div id="mce-responses" class="clear">
             <div class="response" id="mce-error-response" style="display:none"></div>
@@ -25,7 +39,7 @@
             <input type="submit" value="{{ f.button }}" class="usa-button">
           </div>
         </div>
-        <div class="usa-width-one-half" style="margin-top: 1.5rem;">
+        <div style="margin-top: 1.5rem;">
           {% if f.privacypolicy %}
             <p>{{ f.privacypolicy }}</p>
           {% else %}


### PR DESCRIPTION
In order to target leads with appropriate messaging based on their function and sector the Skyporter team / business team made some changes to the sign up form.

This change is to update the form on the cloud.gov homepage itself.

[Help needed]
The form works (I tested locally and confirmed data in mailchimp).

Only problem:
The styling is funky on the dropdown fields. Would love it if someone could fix the CSS or let me know what I should change!

![image](https://cloud.githubusercontent.com/assets/4535280/18801834/0a153f02-819a-11e6-817d-4b0c187893a4.png)
